### PR TITLE
CDC-25: Change interaction behaviour in crosstab

### DIFF
--- a/packages/muze-firebolt/src/enums/actions.js
+++ b/packages/muze-firebolt/src/enums/actions.js
@@ -4,4 +4,4 @@ export const SELECTIONDRAG = 'selectiondrag';
 export const CLICK = 'click';
 export const LONGTOUCH = 'longtouch';
 export const TOUCHDRAG = 'touchdrag';
-
+export const ALL_ACTIONS = '*';

--- a/packages/muze-firebolt/src/side-effects/anchors/index.js
+++ b/packages/muze-firebolt/src/side-effects/anchors/index.js
@@ -91,7 +91,7 @@ export default class AnchorEffect extends SpawnableSideEffect {
             const instances = layer.instances;
             const elems = this.createElement(anchorGroup, 'g', instances, className);
             const linkedLayer = layer.linkedLayer;
-            const [transformedData, schema] = linkedLayer.getTransformedDataFromIdentifiers(dataModel.getData().uids);
+            const [transformedData, schema] = linkedLayer.getTransformedDataFromIdentifiers(dataModel);
             const transformedDataModel = new DataModel(transformedData, schema);
             elems.each(function (d, i) {
                 instances[i].data(transformedDataModel).mount(this);

--- a/packages/muze/src/action-model.js
+++ b/packages/muze/src/action-model.js
@@ -98,7 +98,7 @@ class ActionModel {
             canvas.once('canvas.updated').then((args) => {
                 const matrix = args.client.composition().visualGroup.matrixInstance().value;
                 matrix.each((cell) => {
-                    maps.forEach(val => cell.valueOf().firebolt().dissociateBehaviour(val[0], val[1]));
+                    maps.forEach(val => cell.valueOf().firebolt().dissociateSideEffect(val[0], val[1]));
                 });
             });
         });

--- a/packages/muze/src/canvas/canvas.js
+++ b/packages/muze/src/canvas/canvas.js
@@ -40,13 +40,12 @@ export default class Canvas extends TransactionSupport {
         this._composition.layout = new GridLayout();
         this._store = new Store({});
 
-        this.firebolt(new GroupFireBolt(this));
-
         // Setters and getters will be mounted on this. The object will be mutated.
         const [, store] = transactor(this, options, this._store.model);
         transactor(this, localOptions, store);
         transactor(this, canvasOptions, store);
         this.dependencies(Object.assign({}, globalDependencies, this._dependencies));
+        this.firebolt(new GroupFireBolt(this));
         this.alias(`canvas-${getUniqueId()}`);
         this.title('', {});
         this.subtitle('', {});

--- a/packages/muze/src/canvas/firebolt.js
+++ b/packages/muze/src/canvas/firebolt.js
@@ -1,10 +1,63 @@
 import {
-    getDataModelFromIdentifiers
+    getDataModelFromIdentifiers,
+    FieldType
 } from 'muze-utils';
+
+import { applyInteractionPolicy } from './helper';
+
+const defaultInteractionPolicy = (valueMatrix, firebolt) => {
+    const isMeasure = field => field.type() === FieldType.MEASURE;
+    const canvas = firebolt.context;
+    const visualGroup = canvas.composition().visualGroup;
+    const xFields = [].concat(...visualGroup.getFieldsFromChannel('x'));
+    const yFields = [].concat(...visualGroup.getFieldsFromChannel('y'));
+    const colDim = xFields.every(field => field.type() === FieldType.DIMENSION);
+    const fieldInf = visualGroup.resolver().getAllFields();
+    const rowFacets = fieldInf.rowFacets;
+    const colFacets = fieldInf.colFacets;
+    valueMatrix.each((cell) => {
+        const unitFireBolt = cell.valueOf().firebolt();
+        unitFireBolt.enableSideEffectOnPropagation('tooltip', (propagationPayload) => {
+            const propagationCanvasAlias = propagationPayload.sourceCanvas;
+            const canvasAlias = canvas.alias();
+            return canvasAlias !== propagationCanvasAlias;
+        });
+        if (!(xFields.every(isMeasure) && yFields.every(isMeasure))) {
+            const facetFields = cell.valueOf().facetByFields()[0];
+            const unitColFacets = facetFields.filter(d => colFacets.findIndex(v => v.equals(d)) !== -1);
+            const unitRowFacets = facetFields.filter(d => rowFacets.findIndex(v => v.equals(d)) !== -1);
+            let propFields;
+            if (colDim) {
+                propFields = unitColFacets.map(d => `${d}`);
+            } else {
+                propFields = unitRowFacets.map(d => `${d}`);
+            }
+
+            unitFireBolt.propagateWith('*', propFields, true);
+        }
+    });
+};
 
 export default class GroupFireBolt {
     constructor (context) {
         this.context = context;
+        this._interactionPolicy = this.constructor.defaultInteractionPolicy();
+        this.context.once('canvas.updated').then(() => {
+            const policy = this._interactionPolicy;
+            applyInteractionPolicy(policy, this);
+        });
+    }
+
+    static defaultInteractionPolicy () {
+        return defaultInteractionPolicy;
+    }
+
+    interactionPolicy (...policy) {
+        if (policy.length) {
+            this._interactionPolicy = policy[0] || this.constructor.defaultInteractionPolicy();
+            return this;
+        }
+        return this._interactionPolicy;
     }
 
     dispatchBehaviour (behaviour, payload) {

--- a/packages/muze/src/canvas/helper.js
+++ b/packages/muze/src/canvas/helper.js
@@ -84,3 +84,9 @@ export const setupChangeListener = (context) => {
     });
 };
 
+export const applyInteractionPolicy = (policy, firebolt) => {
+    const canvas = firebolt.context;
+    const visualGroup = canvas.composition().visualGroup;
+    const valueMatrix = visualGroup.composition().matrices.value;
+    policy(valueMatrix, firebolt);
+};

--- a/packages/visual-group/src/group-helper/matrix-model.js
+++ b/packages/visual-group/src/group-helper/matrix-model.js
@@ -173,7 +173,7 @@ export const getMatrixModel = (dataModel, fieldInfo, callback) => {
             const selectedDataModel = createSelectedDataModel(dataModel, rowFacetFieldNames, val);
 
             // Project the datamodel based on the number of projections (based on last levels)
-            facetInfo.push([rowFacetFieldNames, val]);
+            facetInfo.push([rowFacets, val]);
             rowDataModels.push(...projectRows(selectedDataModel, fieldInfo));
         });
     } else {

--- a/packages/visual-group/src/variable/simple-var.js
+++ b/packages/visual-group/src/variable/simple-var.js
@@ -113,4 +113,8 @@ export default class SimpleVariable extends Variable {
         const fieldSpace = this.data().getFieldspace();
         return fieldSpace.fieldsObj()[this.oneVar()].getMinDiff();
     }
+
+    equals (varInst) {
+        return this.oneVar() === varInst.oneVar();
+    }
 }

--- a/packages/visual-group/src/visual-group/value-matrix.js
+++ b/packages/visual-group/src/visual-group/value-matrix.js
@@ -17,11 +17,15 @@ class ValueMatrix {
         this.matrix(matrixArr);
         this.filter(() => true);
 
-        this.each((el) => {
+        this.each((el, rIdx, cIdx) => {
             const cellValue = el.valueOf();
             if (cellValue && cellValue.id) {
                 const id = cellValue.id();
-                instancesById[id] = cellValue;
+                instancesById[id] = {
+                    instance: cellValue,
+                    rowIndex: rIdx,
+                    colIndex: cIdx
+                };
             }
         });
 

--- a/packages/visual-layer/src/base-layer/base-layer.js
+++ b/packages/visual-layer/src/base-layer/base-layer.js
@@ -481,6 +481,7 @@ export default class BaseLayer extends SimpleLayer {
     }
 
     getTransformedDataFromIdentifiers (identifiers) {
+        const { data: identifierData, schema: identifierSchema } = identifiers.getData();
         const normalizedData = this.store().get(PROPS.NORMALIZED_DATA);
         const fieldsConfig = this.data().getFieldsConfig();
         const {
@@ -502,8 +503,10 @@ export default class BaseLayer extends SimpleLayer {
         const transformedData = [];
         normalizedData.forEach((dataArr) => {
             dataArr.forEach((dataObj) => {
-                const id = dataObj._id;
-                if (identifiers.indexOf(id) !== -1) {
+                const tupleArr = dataObj._data;
+                const exist = identifierSchema.every((obj, i) =>
+                    identifierData.findIndex(d => tupleArr[fieldsConfig[obj.name].index] === d[i]) !== -1);
+                if (exist) {
                     const transformedVal = dataObj[enc];
                     const row = dataObj._data;
                     const tuple = {};

--- a/packages/visual-layer/src/layers/point/point.js
+++ b/packages/visual-layer/src/layers/point/point.js
@@ -25,7 +25,7 @@ import './styles.scss';
 export default class PointLayer extends BaseLayer {
 
     /**
-     *Creates an instance of PointLayer.
+     * Creates an instance of PointLayer.
      * @param {*} args
      * @memberof PointLayer
      */

--- a/packages/visual-unit/src/firebolt/data-propagator.js
+++ b/packages/visual-unit/src/firebolt/data-propagator.js
@@ -1,10 +1,37 @@
-import { isSimpleObject } from 'muze-utils';
+import { isSimpleObject, FieldType, DataModel } from 'muze-utils';
+
+const getModelWithFacetData = (dm, data) => {
+    const dataObj = dm.getData();
+    const schema1 = dataObj.schema;
+    const data1 = dataObj.data;
+    const jsonData = [];
+    const schema2 = data[0].map(d => ({
+        name: `${d}`,
+        type: FieldType.DIMENSION
+    }));
+    const data2 = data[1];
+
+    data1.forEach((d) => {
+        const tuple = {};
+        schema1.forEach((obj, i) => {
+            tuple[obj.name] = d[i];
+        });
+        schema2.forEach((obj, i) => {
+            tuple[obj.name] = data2[i];
+        });
+        jsonData.push(tuple);
+    });
+
+    return new DataModel(jsonData, [...schema1, ...schema2]);
+};
 
 export const propagateValues = (instance, action, config = {}) => {
     let propagationData;
     const payload = config.payload;
     const selectionSet = config.selectionSet;
-    const propagationFields = config.propagationFields[action] || [];
+    const propagationFieldInf = config.propagationFields[action] || {};
+    const propagationFields = propagationFieldInf.fields || [];
+    const append = propagationFieldInf.append;
     const criteria = payload.criteria;
     const context = instance.context;
     const dataModel = context.cachedData()[0];
@@ -28,7 +55,12 @@ export const propagateValues = (instance, action, config = {}) => {
         propagationData = mergedModel ? mergedModel.project(criteriaFields) : null;
     }
 
-    propagationFields.length && propagationData && (propagationData = propagationData.project(propagationFields));
+    if (propagationData !== null && propagationFields.length) {
+        const fields = propagationData.getData().schema.map(d => d.name);
+        propagationData = getModelWithFacetData(propagationData, context.facetByFields());
+        propagationData = propagationData.project(append ? [...fields, ...propagationFields] : propagationFields);
+    }
+
     dataModel.addToPropNamespace(sourceId, {
         payload,
         criteria: propagationData,


### PR DESCRIPTION
- Applies a default interaction policy for crosstab to show interactions along the same row or same column.
- Enables tooltips on other canvases while propagation, except for crosstab, enables the tooltip on only the visual unit which is interacted with.
- Fixes wrong transformed data returned from layer when drawing anchors in line and area charts on interaction propagation.