### PR TITLE
Feature/#44 uncaught type error when passed empty array

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -103,7 +103,7 @@
     <script src="js/datamodel.js"></script>
     <script src="js/temp-paths.js"></script>
     <script src="./js/regression.min.js"></script>
-    <script src="./js/empty-array.js"></script>
+    <script src="./js/sample.js"></script>
 </body>
 <link rel='stylesheet' href="./muze.css">
     <style>

--- a/examples/index.html
+++ b/examples/index.html
@@ -103,7 +103,7 @@
     <script src="js/datamodel.js"></script>
     <script src="js/temp-paths.js"></script>
     <script src="./js/regression.min.js"></script>
-    <script src="./js/sample.js"></script>
+    <script src="./js/empty-array.js"></script>
 </body>
 <link rel='stylesheet' href="./muze.css">
     <style>

--- a/examples/js/empty-array.js
+++ b/examples/js/empty-array.js
@@ -1,0 +1,82 @@
+/* global muze, d3 */
+
+let env = muze();
+const SpawnableSideEffect = muze.SideEffects.standards.SpawnableSideEffect;
+const DataModel = muze.DataModel;
+
+d3.json('../data/cars.json', (data) => {
+    const jsonData = data;
+    const schema = [
+        {
+            name: 'Name',
+            type: 'dimension'
+        },
+        {
+            name: 'Maker',
+            type: 'dimension'
+        },
+        {
+            name: 'Miles_per_Gallon',
+            type: 'measure',
+            defAggFn: 'avg'
+        },
+
+        {
+            name: 'Displacement',
+            type: 'measure'
+        },
+        {
+            name: 'Horsepower',
+            type: 'measure',
+            defAggFn: 'avg'
+        },
+        {
+            name: 'Weight_in_lbs',
+            type: 'measure'
+        },
+        {
+            name: 'Acceleration',
+            type: 'measure',
+            defAggFn: 'sum'
+        },
+        {
+            name: 'Origin',
+            type: 'dimension'
+        },
+        {
+            name: 'Cylinders',
+            type: 'dimension'
+        },
+        {
+            name: 'Year',
+            type: 'dimension'
+      // subtype: 'temporal',
+      // format: '%Y-%m-%d'
+        }
+    ];
+    const rootData = new DataModel([], schema);
+    env = env
+    .data([])
+    .minUnitHeight(10)
+    .minUnitWidth(10);
+
+    const crosstab = env
+    .canvas()
+    .rows(['Cylinders', 'Origin'])
+    .columns(['Miles_per_Gallon', 'Horsepower'])
+    // .data(rootData)
+    .color('Acceleration')
+    .width(600)
+    .height(500)
+    .config({
+        border: {
+            color: '#f6f6f6'
+        }
+    })
+    .title('Avg Mileage of cars by Country faceted by Cylinders')
+    .subtitle(
+      'Click on the bars to see how the charts in right gets filtered',
+
+    )
+    .mount('#chart2');
+});

--- a/examples/js/empty-array.js
+++ b/examples/js/empty-array.js
@@ -56,7 +56,7 @@ d3.json('../data/cars.json', (data) => {
     ];
     const rootData = new DataModel([], schema);
     env = env
-    .data([])
+    .data(rootData)
     .minUnitHeight(10)
     .minUnitWidth(10);
 

--- a/packages/layout/src/grid-layout/layout.js
+++ b/packages/layout/src/grid-layout/layout.js
@@ -40,6 +40,22 @@ export default class GridLayout extends GenericLayout {
         this.matrices(matrices);
         this.config(this.constructor.defaultConfig());
         this._layoutId = getUniqueId();
+        this._viewInfo = this.constructor.defaultViewInfo();
+    }
+
+    static defaultViewInfo () {
+        return Object.assign({}, {
+            layoutDimensions: {
+                border: this.defaultConfig().border,
+                viewHeight: [0, 0, 0],
+                viewWidth: [0, 0, 0]
+            },
+            viewMatricesInfo: {
+                columnPages: 0,
+                rowPages: 0,
+                matrices: { top: [], center: [], bottom: [] }
+            }
+        });
     }
 
     /**
@@ -113,7 +129,7 @@ export default class GridLayout extends GenericLayout {
      */
     gotoPage (type, pageNumber) {
         const pageType = type.toLowerCase();
-        const { viewMatricesInfo } = this.getViewInformation();
+        const { viewMatricesInfo } = this.viewInfo();
         const totalPages = viewMatricesInfo[`${pageType}Pages`];
         const pointer = Math.min(Math.max(1, pageNumber), totalPages);
         this.config({
@@ -132,12 +148,20 @@ export default class GridLayout extends GenericLayout {
      * @memberof GridLayout
      */
     pages (type) {
-        const { viewMatricesInfo } = this.getViewInformation();
+        const { viewMatricesInfo } = this.viewInfo();
         const pageType = type.toLowerCase();
         return {
             totalPages: viewMatricesInfo[`${pageType}Pages`],
             currentPage: this.config()[`${pageType}Pointer`] + 1
         };
+    }
+
+    viewInfo (...viewInfo) {
+        if (viewInfo.length) {
+            this._viewInfo = viewInfo[0];
+            return this;
+        }
+        return this._viewInfo;
     }
 
     /**
@@ -155,21 +179,11 @@ export default class GridLayout extends GenericLayout {
         const viewMatricesInfo = getViewMatrices(this, rowPointer, columnPointer);
         const layoutDimensions = getViewMeasurements(this);
         layoutDimensions.border = border;
-        this.viewInfo = {
+        this.viewInfo({
             viewMatricesInfo,
             layoutDimensions
-        };
+        });
         return this;
-    }
-
-    /**
-     *
-     *
-     * @returns
-     * @memberof GridLayout
-     */
-    getViewInformation () {
-        return this.viewInfo;
     }
 
     /**
@@ -183,11 +197,12 @@ export default class GridLayout extends GenericLayout {
         if (!this.mountPoint()) {
             return this;
         }
+        const viewInfo = this.viewInfo();
         const {
-            viewMatricesInfo,
-            layoutDimensions
-        } = this.getViewInformation();
-        // Render matrices
+                viewMatricesInfo,
+                layoutDimensions
+            } = viewInfo;
+            // Render matrices
         renderMatrices(this, viewMatricesInfo.matrices, layoutDimensions);
         return this;
     }

--- a/packages/layout/src/grid-layout/layout.js
+++ b/packages/layout/src/grid-layout/layout.js
@@ -44,7 +44,7 @@ export default class GridLayout extends GenericLayout {
     }
 
     static defaultViewInfo () {
-        return Object.assign({}, {
+        return {
             layoutDimensions: {
                 border: this.defaultConfig().border,
                 viewHeight: [0, 0, 0],
@@ -55,7 +55,7 @@ export default class GridLayout extends GenericLayout {
                 rowPages: 0,
                 matrices: { top: [], center: [], bottom: [] }
             }
-        });
+        };
     }
 
     /**
@@ -115,7 +115,7 @@ export default class GridLayout extends GenericLayout {
      */
     triggerReflow () {
         computeLayoutMeasurements(this);
-        this.setViewInformation();
+        this.computeViewInformation();
         return this;
     }
 
@@ -135,7 +135,7 @@ export default class GridLayout extends GenericLayout {
         this.config({
             [`${pageType}Pointer`]: pointer - 1
         });
-        this.setViewInformation();
+        this.computeViewInformation();
         this.renderGrid();
         return this;
     }
@@ -170,7 +170,7 @@ export default class GridLayout extends GenericLayout {
      * @returns
      * @memberof GridLayout
      */
-    setViewInformation () {
+    computeViewInformation () {
         const {
             rowPointer,
             columnPointer,

--- a/packages/muze-utils/src/common-utils.js
+++ b/packages/muze-utils/src/common-utils.js
@@ -727,9 +727,13 @@ const generateGetterSetters = (context, props) => {
     Object.entries(props).forEach((propInfo) => {
         const prop = propInfo[0];
         const typeChecker = propInfo[1].typeChecker;
+        const defVal = propInfo[1].defaultValue;
         const sanitization = propInfo[1].sanitization;
         const prototype = context.constructor.prototype;
         if (!(Object.hasOwnProperty.call(prototype, prop))) {
+            if (defVal) {
+                context[`_${prop}`] = defVal;
+            }
             context[prop] = (...params) => {
                 if (params.length) {
                     let value = params[0];

--- a/packages/muze/src/canvas/helper.js
+++ b/packages/muze/src/canvas/helper.js
@@ -41,6 +41,50 @@ export const dispatchProps = (context) => {
     lifeCycleManager.notify({ client: context, action: 'updated' });
 };
 
+const equalityChecker = (props, params) => {
+    let checker = () => false;
+    return !props.every((option, i) => {
+        switch (option) {
+        case ROWS:
+        case COLUMNS:
+        case DETAIL:
+            checker = isEqual('Array');
+            break;
+
+        case SHAPE:
+        case SIZE:
+        case COLOR:
+        case DATA:
+        case CONFIG:
+            checker = isEqual('Object');
+            break;
+        default:
+            checker = () => true;
+            break;
+        }
+        const oldVal = params[i][0];
+        const newVal = params[i][1];
+
+        return checker(oldVal, newVal);
+    });
+};
+
+const updateChecker = (props, params) => props.every((option, i) => {
+    const val = params[i][1];
+    switch (option) {
+    case ROWS:
+    case COLUMNS:
+        return val !== null;
+
+    case DATA:
+        return val && !val.isEmpty();
+
+    default:
+        return true;
+
+    }
+});
+
 /**
  *
  *
@@ -51,34 +95,13 @@ export const setupChangeListener = (context) => {
     store.registerImmediateListener(MOUNT, () => {
         const allOptions = Object.keys(context._allOptions);
         const props = [...allOptions, ...Object.keys(canvasOptions)];
-        let equalityChecker = () => false;
+
         store.registerChangeListener(props, (...params) => {
-            const updateProps = props.every((option, i) => {
-                switch (option) {
-                case ROWS:
-                case COLUMNS:
-                case DETAIL:
-                    equalityChecker = isEqual('Array');
-                    break;
+            let updateProps = equalityChecker(props, params);
+            updateProps = updateChecker(props, params);
 
-                case SHAPE:
-                case SIZE:
-                case COLOR:
-                case DATA:
-                case CONFIG:
-                    equalityChecker = isEqual('Object');
-                    break;
-                default:
-                    equalityChecker = () => true;
-                    break;
-                }
-                const oldVal = params[i][0];
-                const newVal = params[i][1];
-
-                return equalityChecker(oldVal, newVal);
-            });
             // inform attached board to rerender
-            !updateProps && dispatchProps(context);
+            updateProps && dispatchProps(context);
             context.render();
         }, true);
     });

--- a/packages/muze/src/canvas/layout-maker.js
+++ b/packages/muze/src/canvas/layout-maker.js
@@ -24,7 +24,7 @@ export const prepareLayout = (layout, components, config, measurement) => {
         bottomLeft,
         bottomRight
     } = cornerMatrices;
-    if (rows && columns) {
+    if (rows.length && columns.length) {
         layout.measurement(measurement)
                         .config(config)
                         .matrices({

--- a/packages/muze/src/canvas/layout-maker.js
+++ b/packages/muze/src/canvas/layout-maker.js
@@ -24,15 +24,16 @@ export const prepareLayout = (layout, components, config, measurement) => {
         bottomLeft,
         bottomRight
     } = cornerMatrices;
-
-    layout.measurement(measurement)
-                    .config(config)
-                    .matrices({
-                        top: [topLeft, columns[0], topRight],
-                        center: [rows[0], values, rows[1]],
-                        bottom: [bottomLeft, columns[1], bottomRight]
-                    })
-                    .triggerReflow();
+    if (rows && columns) {
+        layout.measurement(measurement)
+                        .config(config)
+                        .matrices({
+                            top: [topLeft, columns[0], topRight],
+                            center: [rows[0], values, rows[1]],
+                            bottom: [bottomLeft, columns[1], bottomRight]
+                        })
+                        .triggerReflow();
+    }
 };
 
 /**

--- a/packages/muze/src/canvas/legend-maker.js
+++ b/packages/muze/src/canvas/legend-maker.js
@@ -162,7 +162,7 @@ export const createLegend = (context, headerHeight, height, width) => {
         width,
         headerHeight
     };
-    if (!context.data() || context.data().isEmpty) {
+    if (!context.data() || context.data().isEmpty()) {
         return [];
     }
     const { legend } = context.config();

--- a/packages/muze/src/canvas/legend-maker.js
+++ b/packages/muze/src/canvas/legend-maker.js
@@ -20,7 +20,7 @@ export const legendCreator = (canvas) => {
         const scaleType = axisInfo[0];
         const scaleProps = canvas[scaleType]();
 
-        if (scaleProps.field) {
+        if (scaleProps.field && scale) {
             const {
                 type,
                 step

--- a/packages/muze/src/canvas/legend-maker.js
+++ b/packages/muze/src/canvas/legend-maker.js
@@ -20,7 +20,7 @@ export const legendCreator = (canvas) => {
         const scaleType = axisInfo[0];
         const scaleProps = canvas[scaleType]();
 
-        if (scaleProps.field && scale) {
+        if (scaleProps.field) {
             const {
                 type,
                 step
@@ -162,6 +162,9 @@ export const createLegend = (context, headerHeight, height, width) => {
         width,
         headerHeight
     };
+    if (!context.data() || context.data().isEmpty) {
+        return [];
+    }
     const { legend } = context.config();
     const { show, position } = legend;
 

--- a/packages/muze/src/canvas/renderer.js
+++ b/packages/muze/src/canvas/renderer.js
@@ -301,15 +301,16 @@ export const renderComponents = (context, components, layoutConfig, measurement)
     const {
         mount
     } = prepareGridContainer(layout.node(), measurement, classPrefix, context.alias());
-    const padding = context.layout().getViewInformation().layoutDimensions.viewWidth[0];
+    const padding = context.layout().viewInfo().layoutDimensions.viewWidth[0];
+
     measurement.padding = padding;
     setLabelRotationForAxes(context);
 
     // Render layout
     context.layout().renderGrid(mount);
+    renderHeader(layoutConfig, title, 'title', headers);
+    renderHeader(layoutConfig, subtitle, 'subtitle', headers);
     context.once('layer.drawn').then(() => {
-        renderHeader(layoutConfig, title, 'title', headers);
-        renderHeader(layoutConfig, subtitle, 'subtitle', headers);
         renderLegend(layoutConfig, legend, legends, measurement);
         shiftHeaders(layoutConfig, padding, measurement, mountPoint);
     });

--- a/packages/visual-group/src/group-helper/matrix-resolver.js
+++ b/packages/visual-group/src/group-helper/matrix-resolver.js
@@ -31,8 +31,8 @@ export default class MatrixResolver {
         this._rowMatrix = [];
         this._columnMatrix = [];
         this._valueMatrix = [];
-        this._facets = {};
-        this._projections = {};
+        this._facets = { rowFacets: [], colFacets: [] };
+        this._projections = { rowProjections: [], colProjections: [] };
         this._datamodelTransform = {};
         this._units = [];
         this._cacheMaps = {};

--- a/packages/visual-group/src/visual-group/change-listener.js
+++ b/packages/visual-group/src/visual-group/change-listener.js
@@ -26,14 +26,11 @@ const sanitizeRetinalConfig = (retinalConf) => {
  * @memberof VisualGroup
  */
 export const setMatrixInstances = (context, placeholder) => {
-    let {
+    const {
         values,
         rows,
         columns
     } = placeholder;
-    values = values || [];
-    rows = rows || [];
-    columns = columns || [];
     context._composition.matrices = {
         value: new ValueMatrix(values),
         left: new ValueMatrix(rows[0]),

--- a/packages/visual-group/src/visual-group/change-listener.js
+++ b/packages/visual-group/src/visual-group/change-listener.js
@@ -25,13 +25,21 @@ const sanitizeRetinalConfig = (retinalConf) => {
  * @param {*} placeholder
  * @memberof VisualGroup
  */
-const setMatrixInstances = (context, placeholder) => {
+export const setMatrixInstances = (context, placeholder) => {
+    let {
+        values,
+        rows,
+        columns
+    } = placeholder;
+    values = values || [];
+    rows = rows || [];
+    columns = columns || [];
     context._composition.matrices = {
-        value: new ValueMatrix(placeholder.values),
-        left: new ValueMatrix(placeholder.rows[0]),
-        right: new ValueMatrix(placeholder.rows[1]),
-        top: new ValueMatrix(placeholder.columns[0]),
-        bottom: new ValueMatrix(placeholder.columns[1])
+        value: new ValueMatrix(values),
+        left: new ValueMatrix(rows[0]),
+        right: new ValueMatrix(rows[1]),
+        top: new ValueMatrix(columns[0]),
+        bottom: new ValueMatrix(columns[1])
     };
     return context;
 };
@@ -47,70 +55,69 @@ export const setupChangeListeners = (context) => {
         const datamodel = context.data();
         const [config, rows, columns, color, shape, size, detail, layers, transform] = params;
 
-        if (datamodel && rows[1] && columns[1]) {
-            // Get the resolver for the matrices
-            const resolver = context.resolver();
-            // Prepare configuration for matrix preparation
-            let matrixConfig = {
-                selection: context.selection(),
-                alias: context.alias(),
-                globalConfig: config[1] || {},
-                rows: rows[1],
-                columns: columns[1],
-                detail: detail[1],
-                layers: layers[1],
-                transform: transform[1]
-            };
+        // Get the resolver for the matrices
+        const resolver = context.resolver();
+        // Prepare configuration for matrix preparation
+        let matrixConfig = {
+            selection: context.selection(),
+            alias: context.alias(),
+            globalConfig: config[1] || {},
+            rows: rows[1],
+            columns: columns[1],
+            detail: detail[1],
+            layers: layers[1],
+            transform: transform[1]
+        };
 
-            const retinalConfig = sanitizeRetinalConfig({
-                color: color[1],
-                shape: shape[1],
-                size: size[1]
-            });
+        const retinalConfig = sanitizeRetinalConfig({
+            color: color[1],
+            shape: shape[1],
+            size: size[1]
+        });
 
-            matrixConfig = Object.assign(matrixConfig, retinalConfig);
-            // Create the encoders for the group
-            const encoders = {};
-            encoders.retinalEncoder = new RetinalEncoder();
-            encoders.simpleEncoder = getEncoder(layers[1]);
+        matrixConfig = Object.assign(matrixConfig, retinalConfig);
+        // Create the encoders for the group
+        const encoders = {};
+        encoders.retinalEncoder = new RetinalEncoder();
+        encoders.simpleEncoder = getEncoder(layers[1]);
 
-            // Set the group type
-            context.groupType(encoders.simpleEncoder.constructor.type());
+        // Set the group type
+        context.groupType(encoders.simpleEncoder.constructor.type());
 
-            // Get sanitized fields as instances of the Vars Class
-            const fields = encoders.simpleEncoder.fieldSanitizer(datamodel, matrixConfig);
-            encoders.simpleEncoder.setAxisAndHeaders(config[1] ? config[1].axisFrom : {}, fields);
-            // Setting layers for the code
-            layers[1] && resolver.layerConfig(layers[1]);
-            // Set the row and column axes
-            resolver.horizontalAxis(fields.rows, encoders).verticalAxis(fields.columns, encoders);
-            // Getting the placeholders
-            const placeholderInfo = resolver.getMatrices(datamodel, matrixConfig, context.registry(), encoders);
-            context._groupedDataModel = placeholderInfo.dataModels.groupedModel;
-            // Set the selection object
-            context.selection(placeholderInfo.selection);
+        // Get sanitized fields as instances of the Vars Class
+        const fields = encoders.simpleEncoder.fieldSanitizer(datamodel, matrixConfig);
+        encoders.simpleEncoder.setAxisAndHeaders(config[1] ? config[1].axisFrom : {}, fields);
+        // Setting layers for the code
+        layers[1] && resolver.layerConfig(layers[1]);
+        // Set the row and column axes
+        resolver.horizontalAxis(fields.rows, encoders).verticalAxis(fields.columns, encoders);
+        // Getting the placeholders
+        const placeholderInfo = resolver.getMatrices(datamodel, matrixConfig, context.registry(), encoders);
+        context._groupedDataModel = placeholderInfo.dataModels.groupedModel;
+        // Set the selection object
+        context.selection(placeholderInfo.selection);
 
-            // Create retinal axes
-            resolver.createRetinalAxes(placeholderInfo.dataModels.parentModel.getFieldsConfig(), retinalConfig,
+        // Create retinal axes
+        resolver.createRetinalAxes(placeholderInfo.dataModels.parentModel.getFieldsConfig(), retinalConfig,
                 encoders);
 
-            // Domains are evaluated for each of the axes for commonality
-            resolver.setDomains(matrixConfig, placeholderInfo.dataModels, encoders);
+        // Domains are evaluated for each of the axes for commonality
+        resolver.setDomains(matrixConfig, placeholderInfo.dataModels, encoders);
 
-            // Create matrix instances
-            setMatrixInstances(context, placeholderInfo);
+        // Create matrix instances
+        setMatrixInstances(context, placeholderInfo);
 
-            // Prepare corner matrices
-            context.cornerMatrices(resolver.createHeaders(placeholderInfo, fields, config[1]));
+        // Prepare corner matrices
+        context.cornerMatrices(resolver.createHeaders(placeholderInfo, fields, config[1]));
 
-             // Set placeholder information
-            context.placeholderInfo(placeholderInfo);
+        // Set placeholder information
+        context.placeholderInfo(placeholderInfo);
 
-            context._composition.axes = resolver.axes();
-            context.metaData({
-                border: getBorders(placeholderInfo, encoders.simpleEncoder)
-            });
-        }
+        context._composition.axes = resolver.axes();
+        context.metaData({
+            border: getBorders(placeholderInfo, encoders.simpleEncoder)
+        });
+
         return context;
     });
     return context;

--- a/packages/visual-group/src/visual-group/props.js
+++ b/packages/visual-group/src/visual-group/props.js
@@ -12,11 +12,24 @@ export const PROPS = {
             return value;
         }
     },
-    cornerMatrices: {},
+    cornerMatrices: {
+        defaultValue: {
+            topLeft: [],
+            topRight: [],
+            bottomLeft: [],
+            bottomRight: []
+        }
+    },
     groupType: {},
-    matrixInstance: {},
-    metaData: {},
-    placeholderInfo: {},
+
+    metaData: {
+        defaultValue: {
+            border: {}
+        }
+    },
+    placeholderInfo: {
+        defaultValue: {}
+    },
     resolver: {},
     registry: {
         sanitization: (context, value) => {

--- a/packages/visual-group/src/visual-group/props.js
+++ b/packages/visual-group/src/visual-group/props.js
@@ -28,7 +28,11 @@ export const PROPS = {
         }
     },
     placeholderInfo: {
-        defaultValue: {}
+        defaultValue: {
+            rows: [],
+            columns: [],
+            values: []
+        }
     },
     resolver: {},
     registry: {

--- a/packages/visual-group/src/visual-group/value-matrix.js
+++ b/packages/visual-group/src/visual-group/value-matrix.js
@@ -14,7 +14,7 @@ class ValueMatrix {
     constructor (matrixArr) {
         const instancesById = {};
 
-        this.matrix(matrixArr);
+        this.matrix(matrixArr || []);
         this.filter(() => true);
 
         this.each((el, rIdx, cIdx) => {

--- a/packages/visual-group/src/visual-group/visual-group.js
+++ b/packages/visual-group/src/visual-group/visual-group.js
@@ -57,7 +57,7 @@ class VisualGroup extends SimpleGroup {
         // Create instance of matrix resolver
         this.resolver(new MatrixResolver(this._dependencies));
         // matrix instance store each of the matrices
-        setMatrixInstances(this, {});
+        setMatrixInstances(this, this.placeholderInfo());
          // Getting indiviual registered items
         this.registry({
             layerRegistry: componentSubRegistry.layerRegistry.get(),

--- a/packages/visual-group/src/visual-group/visual-group.js
+++ b/packages/visual-group/src/visual-group/visual-group.js
@@ -6,7 +6,7 @@ import {
     initStore,
     findInGroup
 } from '../group-helper';
-import { setupChangeListeners } from './change-listener';
+import { setupChangeListeners, setMatrixInstances } from './change-listener';
 import { PROPS } from './props';
 import {
     CONFIG,
@@ -46,24 +46,18 @@ class VisualGroup extends SimpleGroup {
         generateGetterSetters(this, PROPS);
         // Populate the store with default values
         this.store(initStore());
-
         // initialize group compositions
         this._composition = {};
         // store reference to data
         this._data = [];
-        // matrix instance store each of the matrices
-        this._matrixInstance = {};
         // store reference to mountpoint
         this._mount = null;
         // selection object that takes care of updating of components
         this._selection = {};
-        // stores info about the placeholders generated after creation of matrices
-        this._placeholderInfo = {};
-        // corner matrices are the headers/footers for the application
-        this._cornerMatrices = {};
         // Create instance of matrix resolver
         this.resolver(new MatrixResolver(this._dependencies));
-
+        // matrix instance store each of the matrices
+        setMatrixInstances(this, {});
          // Getting indiviual registered items
         this.registry({
             layerRegistry: componentSubRegistry.layerRegistry.get(),
@@ -164,7 +158,6 @@ class VisualGroup extends SimpleGroup {
             rowProjections,
             colProjections
         } = this.resolver().getAllFields();
-
         return channel === Y ? rowProjections : colProjections;
     }
 


### PR DESCRIPTION
When an empty dataModel or dataModel with no data was provided to the Muze, it threw an uncaught typeError. That has been fixed. The title and subtitle will still get drawn but an empty chart will be rendered.
The empty-array sample contains such an example.